### PR TITLE
Correção de Fatal Error

### DIFF
--- a/app/code/community/Silveira/Jadlog/Model/Carrier/Default.php
+++ b/app/code/community/Silveira/Jadlog/Model/Carrier/Default.php
@@ -43,7 +43,6 @@ class Silveira_Jadlog_Model_Carrier_Default extends Mage_Shipping_Model_Carrier_
         } catch (Exception $e) {
             Mage::log("Servidor está offline - ". $e->getMessage() ,null,  'jadlog_errors.log');
             return false;
-            exit;
         }
     }
 


### PR DESCRIPTION
Em caso do servidor estiver fora do ar, acontece uma interrupção da execução do script php, ocasionando um fatal error, devido a instrução 'exit'
